### PR TITLE
depend on CAP 2018.07.10

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -89,10 +89,10 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.8",
+  GAP := ">= 4.9.1",
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
-                   [ "CAP", ">= 2018.04.27" ],
+                   [ "CAP", ">= 2018.07.10" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],


### PR DESCRIPTION
CAP 2018.07.10 includes the required methods for the (co-)equalizer.
Since CAP 2018.07.10 depends on GAP 4.9.1, we cannot test this package with GAP 4.8 and thus explicitly require GAP 4.9.1