### PR TITLE
CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          sudo apt install -y texlive-latex-extra texlive-science
+          sudo apt install -y texlive-latex-extra texlive-science curl
           cd ..
           git clone --depth 1 https://github.com/homalg-project/homalg_project
           git clone --depth 1 https://github.com/homalg-project/CAP_project.git
@@ -15,3 +15,6 @@ jobs:
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
           sed 's/  SuggestedOtherPackages := \[ \[ "Browse", ">=0" \] \],/  SuggestedOtherPackages := [ ],/g' -i ~/.gap/pkg/CAP_project/CAP/PackageInfo.g
           make test | perl -pe 'END { exit $status } $status=1 if /Expected output/;'
+      - run: |
+          make coverage
+          bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: gapsystem/gap-docker:latest
+    working_directory: ~/.gap/pkg/FinSetsForCAP
+    steps:
+      - checkout
+      - run: |
+          sudo apt install -y texlive-latex-extra texlive-science
+          cd ..
+          git clone --depth 1 https://github.com/homalg-project/homalg_project
+          git clone --depth 1 https://github.com/homalg-project/CAP_project.git
+          cd FinSetsForCAP
+          echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
+          sed 's/  SuggestedOtherPackages := \[ \[ "Browse", ">=0" \] \],/  SuggestedOtherPackages := [ ],/g' -i ~/.gap/pkg/CAP_project/CAP/PackageInfo.g
+          make test | perl -pe 'END { exit $status } $status=1 if /Expected output/;'

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "init.g"
+  - "PackageInfo.g"
+  - "read.g"

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ src/*.lo
 
 /tmp/
 /gh-pages/
+
+stats
+coverage.json

--- a/makefile
+++ b/makefile
@@ -13,3 +13,7 @@ clean:
 
 test:	doc
 	gap maketest.g
+
+coverage:	doc
+	gap --cover stats maketest.g
+	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap


### PR DESCRIPTION
This will not automatically enable CircleCI and codecov.io for homalg-project/FinSetsForCAP. However, I would still like to merge this to have easy access to code coverage results in my own repository zickgraf/FinSetsForCAP.