### PR TITLE
Subobject classifier

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -16,6 +16,8 @@ Version := Maximum( [
                    "2017.05.26", ## Julia's version
                    ## this line prevents merge conflicts
                    "2018.08.16", ## Fabian's version
+                   ## this line prevents merge conflicts
+                   "2018.08.31", ## Mario's version
                    ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},
@@ -105,7 +107,7 @@ Dependencies := rec(
   GAP := ">= 4.9.1",
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
-                   [ "CAP", ">= 2018.08.15" ],
+                   [ "CAP", ">= 2018.08.31" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/doc/Doc.autodoc
+++ b/doc/Doc.autodoc
@@ -36,6 +36,8 @@
 @Subsection Topos properties
 @InsertSystem Topos
 
+@Subsection Subobject Classifier
+@InsertSystem SubobjectClassifier
 
 @Chapter The category of skeletal finite sets
 

--- a/examples/SubobjectClassifier.g
+++ b/examples/SubobjectClassifier.g
@@ -9,6 +9,8 @@ A := FinSet([1,5]);
 #! <An object in FinSets>
 m := MapOfFinSets(A, List(AsList(A), x -> [x,x]), S);
 #! <A morphism in FinSets>
+Display(TruthMorphismIntoSubobjectClassifier(FinSets));
+#! [ [ "*" ], [ [ "*", "true" ] ], [ "true", "false" ] ]
 Display(ClassifyingMorphismOfSubobject(m));
 #! [ [ 1, 2, 3, 4, 5 ], [ [ 1, "true" ], [ 2, "false" ], [ 3, "false" ], 
 #! [ 4, "false" ], [ 5, "true" ] ], [ "true", "false" ] ]

--- a/examples/SubobjectClassifier.g
+++ b/examples/SubobjectClassifier.g
@@ -10,6 +10,7 @@ A := FinSet([1,5]);
 m := MapOfFinSets(A, List(AsList(A), x -> [x,x]), S);
 #! <A morphism in FinSets>
 Display(ClassifyingMorphismOfSubobject(m));
-#! [ [ 1, 2, 3, 4, 5 ], [ [ 1, "true" ], [ 2, "false" ], [ 3, "false" ], [ 4, "false" ], [ 5, "true" ] ], [ "true", "false" ] ]
+#! [ [ 1, 2, 3, 4, 5 ], [ [ 1, "true" ], [ 2, "false" ], [ 3, "false" ], 
+#! [ 4, "false" ], [ 5, "true" ] ], [ "true", "false" ] ]
 
 #! @EndExample

--- a/examples/SubobjectClassifier.g
+++ b/examples/SubobjectClassifier.g
@@ -1,0 +1,15 @@
+#! @System SubobjectClassifier
+
+LoadPackage( "FinSetsForCAP" );
+
+#! @Example
+S := FinSet([1,2,3,4,5]);
+#! <An object in FinSets>
+A := FinSet([1,5]);
+#! <An object in FinSets>
+m := MapOfFinSets(A, List(AsList(A), x -> [x,x]), S);
+#! <A morphism in FinSets>
+Display(ClassifyingMorphismOfSubobject(m));
+#! [ [ 1, 2, 3, 4, 5 ], [ [ 1, "true" ], [ 2, "false" ], [ 3, "false" ], [ 4, "false" ], [ 5, "true" ] ], [ "true", "false" ] ]
+
+#! @EndExample

--- a/gap/FinSetsForCAP.gi
+++ b/gap/FinSetsForCAP.gi
@@ -854,6 +854,41 @@ AddTensorProductInternalHomCompatibilityMorphismWithGivenObjects( FinSets,
 end );
 
 ##
+AddSubobjectClassifier( FinSets,
+  function( arg )
+      
+      return FinSetNC( [ "true" , "false" ] );
+      
+end );
+
+##
+AddTruthMorphismIntoSubobjectClassifierWithGivenObjects( FinSets, 
+  function( terminal , subobject )
+      
+      return MapOfFinSets(terminal, [ [ "*" , "true" ] ], subobject);
+      
+end );
+
+##
+AddClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier( FinSets,
+  function( monomorphism , omega )
+      local range, image, r, x;
+
+      r := [];
+      range := Range(monomorphism);
+
+      for x in range do
+          if x in ImageObject(monomorphism) then
+              Add(r, [x , "true"]);
+          else
+              Add(r, [x , "false"]);
+          fi;
+      od;
+            
+      return MapOfFinSets(range, r, omega);
+end );
+
+##
 Finalize( FinSets );
 
 ##


### PR DESCRIPTION
This pull request depends on homalg-project/CAP_project#180 being accepted. It implements the set [true,false] as the subobject classifier with a truth morphism ("*" ↦ "true") and a function that takes a monomorphism and outputs its classifying morphism. 

An example of its usage is:

``` GAP
S := FinSet([1,2,3,4,5]);;
A := FinSet([1,5]);;
m := MapOfFinSets(A, List(AsList(A), x -> [x,x]), S);;
Display(ClassifyingMorphismOfSubobject(m));;
```

```
[ [ 1, 2, 3, 4, 5 ], 
  [ [ 1, "true" ], [ 2, "false" ], [ 3, "false" ], [ 4, "false" ], 
      [ 5, "true" ] ], [ "true", "false" ] ]
```
