### PR TITLE
made two direct-product-related CAP operations purely functional for SkeletalFinSets

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The elementary topos of (skeletal) finite sets",
-Version := "2021.12-04",
+Version := "2021.12-05",
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The elementary topos of (skeletal) finite sets",
-Version := "2021.12-05",
+Version := "2021.12-06",
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/examples/PrecompileCategoryOfSkeletalFinSets.g
+++ b/examples/PrecompileCategoryOfSkeletalFinSets.g
@@ -12,22 +12,12 @@ given_arguments := [ ];;
 compiled_category_name := "CategoryOfSkeletalFinSetsPrecompiled";;
 package_name := "FinSetsForCAP";;
 
-uncompiled_SkeletalFinSets :=
-    CategoryOfSkeletalFinSets( : no_precompiled_code := true );;
-
 CapJitPrecompileCategoryAndCompareResult(
     category_constructor,
     given_arguments,
     package_name,
     compiled_category_name
-    : operations := Difference(
-        ListPrimitivelyInstalledOperationsOfCategory(
-            uncompiled_SkeletalFinSets
-        ),
-        [
-            "UniversalMorphismIntoDirectProduct", # uses CAP prepare functions
-        ]
-    )
+    : operations := "primitive"
 );;
 
 CategoryOfSkeletalFinSetsPrecompiled( );

--- a/examples/PrecompileCategoryOfSkeletalFinSets.g
+++ b/examples/PrecompileCategoryOfSkeletalFinSets.g
@@ -25,7 +25,6 @@ CapJitPrecompileCategoryAndCompareResult(
             uncompiled_SkeletalFinSets
         ),
         [
-            "ProjectionInFactorOfDirectProduct", # uses CAP prepare functions
             "UniversalMorphismIntoDirectProduct", # uses CAP prepare functions
         ]
     )

--- a/examples/SkeletalFiberProduct.g
+++ b/examples/SkeletalFiberProduct.g
@@ -10,13 +10,13 @@ n1 := FinSet( 3 );
 iota1 := EmbeddingOfFinSets( n1, m );
 #! <A monomorphism in SkeletalFinSets>
 Display( iota1 );
-#! [ 3, [ 1, 2, 3 ], 5 ]
+#! [ 3, [ 1 .. 3 ], 5 ]
 n2 := FinSet( 4 );
 #! <An object in SkeletalFinSets>
 iota2 := EmbeddingOfFinSets( n2, m );
 #! <A monomorphism in SkeletalFinSets>
 Display( iota2 );
-#! [ 4, [ 1, 2, 3, 4 ], 5 ]
+#! [ 4, [ 1 .. 4 ], 5 ]
 D := [ iota1, iota2 ];
 #! [ <A monomorphism in SkeletalFinSets>, <A monomorphism in SkeletalFinSets> ]
 Fib := FiberProduct( D );

--- a/examples/SkeletalPushout.g
+++ b/examples/SkeletalPushout.g
@@ -10,13 +10,13 @@ N1 := FinSet( 3 );
 iota1 := EmbeddingOfFinSets( N1, M );
 #! <A monomorphism in SkeletalFinSets>
 Display( iota1 );
-#! [ 3, [ 1, 2, 3 ], 5 ]
+#! [ 3, [ 1 .. 3 ], 5 ]
 N2 := FinSet( 2 );
 #! <An object in SkeletalFinSets>
 iota2 := EmbeddingOfFinSets( N2, M );
 #! <A monomorphism in SkeletalFinSets>
 Display( iota2 );
-#! [ 2, [ 1, 2 ], 5 ]
+#! [ 2, [ 1 .. 2 ], 5 ]
 D := [ iota1, iota2 ];
 #! [ <A monomorphism in SkeletalFinSets>, <A monomorphism in SkeletalFinSets> ]
 Fib := FiberProduct( D );

--- a/gap/FinSetsForCAP.gi
+++ b/gap/FinSetsForCAP.gi
@@ -609,13 +609,11 @@ end );
 ##
 AddUniversalMorphismIntoDirectProductWithGivenDirectProduct( category_of_finite_sets,
   function ( category_of_finite_sets, D, test_object, tau, T )
-    local S, Graph;
+    local Graph;
     
-    S := Source( tau[1] );
+    Graph := List( AsList( test_object ), x -> [ x, List( tau, f -> f(x) ) ] );
     
-    Graph := List( AsList( S ), x -> [ x, List( tau, f -> f(x) ) ] );
-    
-    return MapOfFinSetsNC( S, Graph, T );
+    return MapOfFinSetsNC( test_object, Graph, T );
     
 end );
 

--- a/gap/SkeletalFinSetsForCAP.gi
+++ b/gap/SkeletalFinSetsForCAP.gi
@@ -104,7 +104,7 @@ InstallMethod( EmbeddingOfFinSets,
   function ( s, t )
     local iota;
     
-    iota := MapOfFinSets( s, List( s, x -> x ), t );
+    iota := MapOfFinSets( s, AsList( s ), t );
     
     Assert( 3, IsMonomorphism( iota ) );
     SetIsMonomorphism( iota, true );

--- a/gap/SkeletalFinSetsForCAP.gi
+++ b/gap/SkeletalFinSetsForCAP.gi
@@ -543,23 +543,21 @@ AddProjectionInFactorOfDirectProductWithGivenDirectProduct( SkeletalFinSets,
 end );
 
 ##
-AddUniversalMorphismIntoDirectProduct( SkeletalFinSets, CAPOperationPrepareFunction( "UniversalMorphismIntoBinaryDirectProductToUniversalMorphismIntoDirectProduct", SkeletalFinSets, function ( cat, tau1, tau2 )
-    local S, T, n, imgs, i;
+AddUniversalMorphismIntoDirectProductWithGivenDirectProduct( SkeletalFinSets,
+  function ( cat, D, T, tau, P )
+    local l, d, dd, taus;
     
-    S := Source( tau1 );
-    T := DirectProduct( [ Range( tau1 ), Range( tau2 ) ] );
+    l := Length( D );
     
-    n := Length( Range( tau2 ) );
+    d := List( D, x -> Length( x ) );
     
-    imgs := [ ];
+    dd := List( [ 1 .. l ], i -> Product( d{[ i + 1 .. l ]} ) );
     
-    for i in AsList( S ) do
-        Add( imgs, (AsList( tau1 )[i] - 1) * n + AsList( tau2 )[i] );
-    od;
+    taus := List( tau, x -> AsList( x ) );
     
-    return MapOfFinSets( S, imgs, T );
+    return MapOfFinSets( T, List( AsList( T ), i -> 1 + Sum( [ 1 .. l ], j -> ( taus[j][i] - 1 ) * dd[j] ) ), P );
     
-end ) );
+end );
 
 ##
 AddEqualizer( SkeletalFinSets,

--- a/gap/SkeletalFinSetsForCAP.gi
+++ b/gap/SkeletalFinSetsForCAP.gi
@@ -528,32 +528,19 @@ AddDirectProduct( SkeletalFinSets,
 end );
 
 ##
-AddProjectionInFactorOfDirectProduct( SkeletalFinSets, CAPOperationPrepareFunction( "ProjectionInFactorOfBinaryDirectProductToProjectionInFactorOfDirectProduct", SkeletalFinSets, function ( cat, M, N, pos )
-    local S, T, n, imgs, i;
+AddProjectionInFactorOfDirectProductWithGivenDirectProduct( SkeletalFinSets,
+  function ( cat, D, k, P )
+    local T, l, a;
     
-    S := DirectProduct( [ M, N ] );
-    if pos = 1 then
-        T := M;
-    else
-        T := N;
-    fi;
+    T := D[k];
     
-    n := Length( N );
+    l := Length( T );
     
-    imgs := [ ];
-
-    for i in AsList( S ) do
-        if pos = 2 then
-            Add( imgs, (i - 1) mod n );
-        else
-            Add( imgs, Int( (i - 1) / n ) );
-        fi;
-    od;
+    a := Product( D{[ k + 1 .. Length( D ) ]}, M -> Length( M ) );
     
-    imgs := List( imgs, img -> img + 1 );
-
-    return MapOfFinSets( S, imgs, T );
-end ) );
+    return MapOfFinSets( P, List( [ 0 .. Length( P ) - 1 ], i -> 1 + RemInt( QuoInt( i, a ), l ) ), T );
+    
+end );
 
 ##
 AddUniversalMorphismIntoDirectProduct( SkeletalFinSets, CAPOperationPrepareFunction( "UniversalMorphismIntoBinaryDirectProductToUniversalMorphismIntoDirectProduct", SkeletalFinSets, function ( cat, tau1, tau2 )

--- a/gap/precompiled_categories/CategoryOfSkeletalFinSetsPrecompiled.gi
+++ b/gap/precompiled_categories/CategoryOfSkeletalFinSetsPrecompiled.gi
@@ -635,6 +635,25 @@ end
     , 100 );
     
     ##
+    AddProjectionInFactorOfDirectProductWithGivenDirectProduct( cat,
+        
+########
+function ( cat_1, objects_1, k_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1;
+    deduped_3_1 := objects_1[k_1];
+    hoisted_2_1 := Length( deduped_3_1 );
+    hoisted_1_1 := Product( objects_1{[ k_1 + 1 .. Length( objects_1 ) ]}, function ( M_2 )
+            return Length( M_2 );
+        end );
+    return MapOfFinSets( P_1, List( [ 0 .. Length( P_1 ) - 1 ], function ( i_2 )
+              return 1 + REM_INT( QUO_INT( i_2, hoisted_1_1 ), hoisted_2_1 );
+          end ), deduped_3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddProjectionOntoCoequalizerWithGivenCoequalizer( cat,
         
 ########

--- a/gap/precompiled_categories/CategoryOfSkeletalFinSetsPrecompiled.gi
+++ b/gap/precompiled_categories/CategoryOfSkeletalFinSetsPrecompiled.gi
@@ -747,6 +747,35 @@ end
     , 100 );
     
     ##
+    AddUniversalMorphismIntoDirectProductWithGivenDirectProduct( cat,
+        
+########
+function ( cat_1, objects_1, T_1, tau_1, P_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := Length( objects_1 );
+    deduped_6_1 := [ 1 .. deduped_7_1 ];
+    hoisted_5_1 := deduped_6_1;
+    hoisted_3_1 := List( objects_1, function ( x_2 )
+            return Length( x_2 );
+        end );
+    hoisted_2_1 := deduped_7_1;
+    hoisted_4_1 := List( deduped_6_1, function ( i_2 )
+            return Product( hoisted_3_1{[ i_2 + 1 .. hoisted_2_1 ]} );
+        end );
+    hoisted_1_1 := List( tau_1, function ( x_2 )
+            return AsList( x_2 );
+        end );
+    return MapOfFinSets( T_1, List( AsList( T_1 ), function ( i_2 )
+              return 1 + Sum( hoisted_5_1, function ( j_3 )
+                        return (hoisted_1_1[j_3][i_2] - 1) * hoisted_4_1[j_3];
+                    end );
+          end ), P_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
     AddUniversalMorphismIntoEqualizerWithGivenEqualizer( cat,
         
 ########


### PR DESCRIPTION
Made the following two CAP operation for `SkeletalFinSets` purely functional

* `ProjectionInFactorOfDirectProductWithGivenDirectProduct`
* `UniversalMorphismIntoDirectProductWithGivenDirectProduct`
