### PR TITLE
Support empty (co)equalizers

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The elementary topos of (skeletal) finite sets",
-Version := "2022.09-09",
+Version := "2022.09-10",
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/FinSetsForCAP.gi
+++ b/gap/FinSetsForCAP.gi
@@ -15,11 +15,7 @@ InstallMethod( CategoryOfFinSets,
     
     FinSets!.category_as_first_argument := true;
     
-    # FinSets supports empty limits except of the following problem:
-    # In `Equalizer`, we compute `D[1]` inside a loop over `D{[ 2 .. Length( D ) ]}`.
-    # This code can deal with empty `D` because in this case the loop body is never executed.
-    # However, CompilerForCAP would hoist `D[1]` out of the loop, so the compiled code will not be valid anymore for empty `D`.
-    #FinSets!.supports_empty_limits := true;
+    FinSets!.supports_empty_limits := true;
     
     FinSets!.compiler_hints := rec(
         category_filter := IsCategoryOfFinSets,
@@ -808,7 +804,7 @@ end );
 AddEqualizer( category_of_finite_sets,
   function ( category_of_finite_sets, S, D )
     
-    return Filtered( S, x -> ForAll( D{[ 2 .. Length( D ) ]}, fj -> IsEqualForElementsOfFinSets( D[1]( x ), fj( x ) ) ) );
+    return Filtered( S, x -> ForAll( [ 1 .. Length( D ) - 1 ], j -> IsEqualForElementsOfFinSets( D[j]( x ), D[j + 1]( x ) ) ) );
     
 end );
 

--- a/gap/SkeletalFinSetsForCAP.gi
+++ b/gap/SkeletalFinSetsForCAP.gi
@@ -15,11 +15,7 @@ InstallMethod( CategoryOfSkeletalFinSets,
     
     cat!.category_as_first_argument := true;
     
-    # SkeletalFinSets supports empty limits except of the following problem:
-    # In `Equalizer`, we compute `D2[1]` inside a loop over `D2{[ 2 .. Length( D ) ]}`.
-    # This code can deal with empty `D` because in this case the loop body is never executed.
-    # However, CompilerForCAP would hoist `D2[1]` out of the loop, so the compiled code will not be valid anymore for empty `D`.
-    #cat!.supports_empty_limits := true;
+    cat!.supports_empty_limits := true;
     
     cat!.compiler_hints := rec(
         category_filter := IsCategoryOfSkeletalFinSets,
@@ -598,7 +594,7 @@ AddEqualizer( SkeletalFinSets,
     
     D2 := List( D, AsList );
     
-    Eq := Filtered( [ 0 .. Length( s ) - 1 ], x -> ForAll( D2{[ 2 .. Length( D ) ]}, fj -> D2[1][1 + x] = fj[1 + x] ) );
+    Eq := Filtered( [ 0 .. Length( s ) - 1 ], x -> ForAll( [ 1 .. Length( D ) - 1 ], j -> D2[j][1 + x] = D2[j + 1][1 + x] ) );
     
     return FinSet( SkeletalFinSets, Length( Eq ) );
     
@@ -611,7 +607,7 @@ AddEmbeddingOfEqualizerWithGivenEqualizer( SkeletalFinSets,
     
     D2 := List( D, AsList );
     
-    Eq := Filtered( [ 0 .. Length( s ) - 1 ], x -> ForAll( D2{[ 2 .. Length( D ) ]}, fj -> D2[1][1 + x] = fj[1 + x] ) );
+    Eq := Filtered( [ 0 .. Length( s ) - 1 ], x -> ForAll( [ 1 .. Length( D ) - 1 ], j -> D2[j][1 + x] = D2[j + 1][1 + x] ) );
     
     return MapOfFinSets( cat, E, Eq, s );
     
@@ -624,7 +620,7 @@ AddUniversalMorphismIntoEqualizerWithGivenEqualizer( SkeletalFinSets,
     
     D2 := List( D, AsList );
     
-    Eq := Filtered( [ 0 .. Length( s ) - 1 ], x -> ForAll( D2{[ 2 .. Length( D ) ]}, fj -> D2[1][1 + x] = fj[1 + x] ) );
+    Eq := Filtered( [ 0 .. Length( s ) - 1 ], x -> ForAll( [ 1 .. Length( D ) - 1 ], j -> D2[j][1 + x] = D2[j + 1][1 + x] ) );
     
     t := AsList( tau );
     

--- a/gap/precompiled_categories/CategoryOfSkeletalFinSetsPrecompiled.gi
+++ b/gap/precompiled_categories/CategoryOfSkeletalFinSetsPrecompiled.gi
@@ -281,17 +281,14 @@ end
         
 ########
 function ( cat_1, Y_1, morphisms_1, P_1 )
-    local hoisted_1_1, hoisted_2_1, deduped_3_1;
-    deduped_3_1 := List( morphisms_1, AsList );
-    hoisted_2_1 := deduped_3_1{[ 2 .. Length( morphisms_1 ) ]};
-    hoisted_1_1 := deduped_3_1[1];
+    local hoisted_1_1, hoisted_2_1;
+    hoisted_2_1 := [ 1 .. Length( morphisms_1 ) - 1 ];
+    hoisted_1_1 := List( morphisms_1, AsList );
     return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Y_1, AsList, Filtered( [ 0 .. Length( Y_1 ) - 1 ], function ( x_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + x_2;
-              hoisted_2_2 := hoisted_1_1[deduped_3_2];
-              hoisted_1_2 := deduped_3_2;
-              return ForAll( hoisted_2_1, function ( fj_3 )
-                      return hoisted_2_2 = fj_3[hoisted_1_2];
+              local hoisted_1_2;
+              hoisted_1_2 := 1 + x_2;
+              return ForAll( hoisted_2_1, function ( j_3 )
+                      return hoisted_1_1[j_3][hoisted_1_2] = hoisted_1_1[j_3 + 1][hoisted_1_2];
                   end );
           end ) );
 end
@@ -315,17 +312,14 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, deduped_3_1;
-    deduped_3_1 := List( arg3_1, AsList );
-    hoisted_2_1 := deduped_3_1{[ 2 .. Length( arg3_1 ) ]};
-    hoisted_1_1 := deduped_3_1[1];
+    local hoisted_1_1, hoisted_2_1;
+    hoisted_2_1 := [ 1 .. Length( arg3_1 ) - 1 ];
+    hoisted_1_1 := List( arg3_1, AsList );
     return CreateCapCategoryObjectWithAttributes( cat_1, Length, Length( Filtered( [ 0 .. Length( arg2_1 ) - 1 ], function ( x_2 )
-                local hoisted_1_2, hoisted_2_2, deduped_3_2;
-                deduped_3_2 := 1 + x_2;
-                hoisted_2_2 := hoisted_1_1[deduped_3_2];
-                hoisted_1_2 := deduped_3_2;
-                return ForAll( hoisted_2_1, function ( fj_3 )
-                        return hoisted_2_2 = fj_3[hoisted_1_2];
+                local hoisted_1_2;
+                hoisted_1_2 := 1 + x_2;
+                return ForAll( hoisted_2_1, function ( j_3 )
+                        return hoisted_1_1[j_3][hoisted_1_2] = hoisted_1_1[j_3 + 1][hoisted_1_2];
                     end );
             end ) ) );
 end
@@ -904,17 +898,14 @@ end
         
 ########
 function ( cat_1, Y_1, morphisms_1, T_1, tau_1, P_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, deduped_5_1;
-    deduped_5_1 := List( morphisms_1, AsList );
-    hoisted_2_1 := deduped_5_1{[ 2 .. Length( morphisms_1 ) ]};
-    hoisted_1_1 := deduped_5_1[1];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1;
+    hoisted_2_1 := [ 1 .. Length( morphisms_1 ) - 1 ];
+    hoisted_1_1 := List( morphisms_1, AsList );
     hoisted_4_1 := Filtered( [ 0 .. Length( Y_1 ) - 1 ], function ( x_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + x_2;
-            hoisted_2_2 := hoisted_1_1[deduped_3_2];
-            hoisted_1_2 := deduped_3_2;
-            return ForAll( hoisted_2_1, function ( fj_3 )
-                    return hoisted_2_2 = fj_3[hoisted_1_2];
+            local hoisted_1_2;
+            hoisted_1_2 := 1 + x_2;
+            return ForAll( hoisted_2_1, function ( j_3 )
+                    return hoisted_1_1[j_3][hoisted_1_2] = hoisted_1_1[j_3 + 1][hoisted_1_2];
                 end );
         end );
     hoisted_3_1 := AsList( tau_1 );


### PR DESCRIPTION
by comparing each entry to its successor instead of all entries to the first one.

This was easier then expected :D

Fixes #83.