### PR TITLE
Remove obsolete permissions fixes

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -22,9 +22,6 @@ jobs:
     steps:
       # keep workflow active even if repository has no activity for 60 days (do not execute for pull requests)
       - run: '[ "$GITHUB_EVENT_NAME" = "pull_request" ] || curl --fail -X PUT -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/Tests.yml/enable'
-      # checkout needs access to temporary directory
-      - run: sudo chmod 1777 $RUNNER_TEMP
-      - run: sudo chown gap:gap $GITHUB_WORKSPACE
       - uses: actions/checkout@v3
       - run: cp -a $GITHUB_WORKSPACE /home/gap/.gap/pkg/
       - run: |


### PR DESCRIPTION
User gap in the docker container now has the same uid/gid as the user GitHub runners use.