### PR TITLE
Only make documentation of Toposes if it exists as a standalone package

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The elementary topos of (skeletal) finite sets",
-Version := "2023.05-02",
+Version := "2023.05-03",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ test-spacing:
 	rm spacing_diff_no_blanks
 
 test-gap_to_julia: doc
-	make -C ../Toposes doc
+	if [ -d "../Toposes" ]; then make -C "../Toposes" doc; fi
 	git clone https://github.com/homalg-project/PackageJanitor.git ~/.gap/pkg/PackageJanitor
 	mkdir ~/.julia/dev
 	git clone https://github.com/zickgraf/CAP.jl.git ~/.julia/dev/CAP


### PR DESCRIPTION
In the CI of CategoricalTowers Toposes only exists as a subpackage.