### PR TITLE
Optimize Preimage

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The elementary topos of (skeletal) finite sets",
-Version := "2024.02-04",
+Version := "2024.02-05",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/gap/SkeletalFinSets.gi
+++ b/gap/SkeletalFinSets.gi
@@ -132,13 +132,11 @@ InstallMethod( Preimage,
         [ IsMorphismInSkeletalCategoryOfFiniteSets, IsList ],
         
   function ( phi, t )
-    local S;
+    local positions;
     
-    S := AsList( Source( phi ) );
+    positions := PositionsProperty( AsList( phi ), x -> x in t );
     
-    phi := AsList( phi );
-    
-    return Filtered( S, i -> phi[1 + i] in t );
+    return List( positions, i -> BigInt( i - 1 ) );
     
 end );
 


### PR DESCRIPTION
This is a small improvement for GAP and a large improvement for Julia: In Julia, `positions` is a list of *small* integers, so we avoid many GMP operations. In general, the use of small integers is a problem for correctness. Here, however, we have no chance of looping over `AsList( phi )` anyway if its length is not a small integer in the first place.