### PR TITLE
Only install primitive operations if `no_precompiled_code` is set

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The elementary topos of (skeletal) finite sets",
-Version := "2024.02-07",
+Version := "2024.02-08",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/gap/SkeletalFinSets.gi
+++ b/gap/SkeletalFinSets.gi
@@ -38,14 +38,16 @@ InstallMethod( SkeletalCategoryOfFiniteSets,
     SetRangeCategoryOfHomomorphismStructure( cat, cat );
     SetIsEquippedWithHomomorphismStructure( cat, true );
     
-    INSTALL_FUNCTIONS_FOR_SKELETAL_FIN_SETS( cat );
-    
     #= comment for Julia
     AddTheoremFileToCategory( cat,
             Filename( DirectoriesPackageLibrary( "Toposes", "LogicForToposes" ), "PropositionsForToposes.tex" ) );
     # =#
     
-    if not CAP_NAMED_ARGUMENTS.no_precompiled_code then
+    if CAP_NAMED_ARGUMENTS.no_precompiled_code then
+        
+        INSTALL_FUNCTIONS_FOR_SKELETAL_FIN_SETS( cat );
+        
+    else
         
         ADD_FUNCTIONS_FOR_SkeletalCategoryOfFiniteSetsWithMorphismsGivenByListsPrecompiled( cat );
         


### PR DESCRIPTION
Since all primitive operations are compiled, this does not change the functionality, but prevents overwriting GAP methods.