### PR TITLE
Add Julia-only FinSet(Int) convenience method

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The (skeletal) elementary topos of finite sets",
-Version := "2025.08-02",
+Version := "2025.08-03",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/gap/SkeletalFinSets.gi
+++ b/gap/SkeletalFinSets.gi
@@ -112,6 +112,9 @@ InstallMethod( FinSetOp,
     
 end );
 
+## In Julia `IsInt` is not a synonym to `IsBigInt`, hence we install a convenience method in Julia
+#% G2J:julia-only InstallOtherMethod( FinSet, [ IsSkeletalCategoryOfFiniteSets, IsInt ], { cat, n } -> FinSet( cat, BigInt( n ) ) );
+
 ##
 InstallMethod( AsList,
         "for a CAP skeletal finite set",


### PR DESCRIPTION
In Julia, Int is not BigInt. Add a G2J julia-only InstallOtherMethod so FinSet(cat, n::Int) promotes n to BigInt, ensuring consistent behavior.

Bump version to v2025.08-03