### PR TITLE
Override START_TEST/STOP_TEST_QUIET to preserve no_precompiled_code option

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The (skeletal) elementary topos of finite sets",
-Version := "2026.01-04",
+Version := "2026.04-01",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/tst/testall_no_precompiled_code.g
+++ b/tst/testall_no_precompiled_code.g
@@ -9,6 +9,25 @@ PushOptions(
     )
 );
 
+# In the current GAP master START_TEST and STOP_TEST reset the global options
+# stack (see https://github.com/gap-system/gap/pull/6215).
+# We override them to re-push the no_precompiled_code option after each reset.
+_ORIG_START_TEST := START_TEST;
+START_TEST := function( name )
+    _ORIG_START_TEST( name );
+    if ValueOption( "no_precompiled_code" ) <> true then
+        PushOptions( rec( no_precompiled_code := true ) );
+    fi;
+end;
+
+_ORIG_STOP_TEST_QUIET := STOP_TEST_QUIET;
+STOP_TEST_QUIET := function( args... )
+    CallFuncList( _ORIG_STOP_TEST_QUIET, args );
+    if ValueOption( "no_precompiled_code" ) <> true then
+        PushOptions( rec( no_precompiled_code := true ) );
+    fi;
+end;
+
 options := rec(
     exitGAP := true,
     testOptions := rec(


### PR DESCRIPTION
GAP-master currently resets the global options stack in START_TEST and STOP_TEST (https://github.com/gap-system/gap/pull/6215), causing the no_precompiled_code option to be lost in the test files (i.e., equals _fail_ instead of _true_).

Bump to v2026.04-01

I am not sure whether this is the best solution.  ̶I̶ ̶w̶a̶s̶ ̶t̶h̶i̶n̶k̶i̶n̶g̶ ̶a̶b̶o̶u̶t̶ ̶p̶a̶s̶s̶i̶n̶g̶ ̶t̶h̶e̶ ̶o̶p̶t̶i̶o̶n̶ ̶a̶s̶ ̶a̶n̶ ̶e̶n̶v̶i̶r̶o̶n̶m̶e̶n̶t̶ ̶v̶a̶r̶i̶a̶b̶l̶e̶,̶ ̶b̶u̶t̶ ̶t̶h̶a̶t̶ ̶w̶o̶u̶l̶d̶ ̶f̶o̶r̶c̶e̶ ̶u̶s̶ ̶t̶o̶ ̶c̶h̶a̶n̶g̶e̶ ̶h̶o̶w̶ ̶e̶x̶a̶m̶p̶l̶e̶s̶ ̶r̶e̶c̶e̶i̶v̶e̶s̶ ̶t̶h̶e̶ ̶o̶p̶t̶i̶o̶n̶. An alternative would be to just define a variable `no_precomplied_code := true` and check for it in the examples/tests using `IsBound( no_precompiled_code ) and no_precompiled_code`