### PR TITLE
Fix IsLiftable check in FinSets

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinSetsForCAP",
 Subtitle := "The (skeletal) elementary topos of finite sets",
-Version := "2026.04-02",
+Version := "2026.04-03",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/doc/Doc.autodoc
+++ b/doc/Doc.autodoc
@@ -220,6 +220,9 @@
 @Subsection Lift
 @InsertChunk Lift
 
+@Subsection Colift
+@InsertChunk Colift
+
 @Subsection Singleton morphism
 @InsertChunk SingletonMorphism
 

--- a/examples/Colift.g
+++ b/examples/Colift.g
@@ -1,0 +1,32 @@
+#! @Chunk Colift
+
+#! @Example
+LoadPackage( "FinSetsForCAP", false );
+#! true
+m := FinSet( [ 1 .. 3 ] );
+#! <An object in FinSets>
+n := FinSet( [ 1 .. 4 ] );
+#! <An object in FinSets>
+alpha := MapOfFinSets( m, [ [ 1, 1 ], [ 2, 2 ], [ 3, 3 ] ], n );
+#! <A morphism in FinSets>
+beta := MapOfFinSets( m, [ [ 1, 2 ], [ 2, 2 ], [ 3, 1 ] ], m );
+#! <A morphism in FinSets>
+IsColiftable( alpha, beta );
+#! true
+chi := Colift( alpha, beta );
+#! <A morphism in FinSets>
+Display( chi );
+#! [ [ 1 .. 4 ], [ [ 1, 2 ], [ 2, 2 ], [ 3, 1 ], [ 4, 1 ] ], [ 1 .. 3 ] ]
+PreCompose( alpha, Colift( alpha, beta ) ) = beta;
+#! true
+IsColiftable( beta, alpha );
+#! false
+k := FinSet( [ 1 .. 3 ] );
+#! <An object in FinSets>
+h := MapOfFinSets( m, [ [ 1, 1 ], [ 2, 2 ], [ 3, 3 ] ], k );
+#! <A morphism in FinSets>
+IsColiftable( h, beta );
+#! true
+IsColiftable( beta, h );
+#! false
+#! @EndExample

--- a/gap/FinSets.gi
+++ b/gap/FinSets.gi
@@ -768,8 +768,12 @@ end );
 ##
 AddIsLiftable( category_of_finite_sets,
   function ( category_of_finite_sets, beta, alpha )
+    local image_beta, image_alpha;
     
-    return IsSubset( AsList( ImageObject( alpha ) ), AsList( ImageObject( beta ) ) );
+    image_beta := AsList( ImageObject( beta ) );
+    image_alpha := AsList( ImageObject( alpha ) );
+    
+    return ForAll( image_beta, e -> e in image_alpha );
     
 end );
 


### PR DESCRIPTION
- Fix IsLiftable for FinSets: check image(beta) ⊆ image(alpha) using ForAll because `Subset` requires the elements in the provided lists to be comparable using < (which cannot always be guaranteed)
- Add Colift subsection and chunk to documentation (IsColiftable delegates via a derivation to IsLiftable)

Bump FinSetsForCAP to v2026.04-03

Resolves https://github.com/homalg-project/FinSetsForCAP/issues/281